### PR TITLE
Include <string.h> in pwlogin.c for strdup()

### DIFF
--- a/pwlogin.c
+++ b/pwlogin.c
@@ -19,6 +19,7 @@
 #include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>


### PR DESCRIPTION
This is necessary for building with newer clang versions.