### PR TITLE
Support disabling password login via -l flag to passwd and fix exit code error in passwd

### DIFF
--- a/passwd.c
+++ b/passwd.c
@@ -55,7 +55,20 @@ static char *read_password(const char *prompt) {
     return password;
 }
 
-int main(void) {
+static int main_remove_password(void) {
+    int ret = EXIT_FAILURE;
+
+    if (termux_remove_passwd()) {
+        puts("Password login successfully disabled.");
+        ret = EXIT_SUCCESS;
+    } else {
+        puts("Failed to disable password login.");
+    }
+
+    return ret;
+}
+
+static int main_set_password(void) {
     char *password;
     char *password_confirmation;
     int ret = EXIT_FAILURE;
@@ -94,4 +107,19 @@ int main(void) {
     free(password_confirmation);
 
     return ret;
+}
+
+int main(int argc, char **argv) {
+    switch (argc) {
+    case 1:
+        return main_set_password();
+    case 2:
+        if (strcmp(argv[1], "-d") == 0) {
+            return main_remove_password();
+        }
+        // otherwise, fall through
+    default:
+        fprintf(stderr, "Supported options are no options or -d\n");
+        return EXIT_FAILURE;
+    }
 }

--- a/passwd.c
+++ b/passwd.c
@@ -18,6 +18,7 @@
 
 /** Utility for setting new password **/
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -62,6 +63,11 @@ static int main_remove_password(void) {
         puts("Password login successfully disabled.");
         ret = EXIT_SUCCESS;
     } else {
+        if (errno == EISDIR) {
+            printf("Unexpectedly found directory where hashed password should be ("
+                   AUTH_HASH_FILE_PATH
+                   "), ignoring\n");
+        }
         puts("Failed to disable password login.");
     }
 

--- a/passwd.c
+++ b/passwd.c
@@ -93,5 +93,5 @@ int main(void) {
     free(password);
     free(password_confirmation);
 
-    return EXIT_SUCCESS;
+    return ret;
 }

--- a/passwd.c
+++ b/passwd.c
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
         // otherwise, fall through
     default:
         fprintf(stderr,
-                "Run %s without args to set a password, or with -d to remove the password\n",
+                "Run %s without args to set a password. Pass option -d to disable authentication credentials (lock account).\n",
                 argv[0]);
         return EXIT_FAILURE;
     }

--- a/passwd.c
+++ b/passwd.c
@@ -125,7 +125,9 @@ int main(int argc, char **argv) {
         }
         // otherwise, fall through
     default:
-        fprintf(stderr, "Supported options are no options or -d\n");
+        fprintf(stderr,
+                "Run %s without args to set a password, or with -d to remove the password\n",
+                argv[0]);
         return EXIT_FAILURE;
     }
 }

--- a/passwd.c
+++ b/passwd.c
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
     case 1:
         return main_set_password();
     case 2:
-        if (strcmp(argv[1], "-d") == 0) {
+        if (strcmp(argv[1], "-d") == 0 || strcmp(argv[1], "-l") == 0) {
             return main_remove_password();
         }
         // otherwise, fall through

--- a/termux-auth.c
+++ b/termux-auth.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <termios.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include <openssl/sha.h>
 #include <openssl/evp.h>
@@ -92,9 +93,9 @@ bool termux_change_passwd(const char *new_password) {
 // Remove file that stores password hash
 // Return true on success, false otherwise.
 bool termux_remove_passwd(void) {
-    int n = remove(AUTH_HASH_FILE_PATH);
+    int n = unlink(AUTH_HASH_FILE_PATH);
 
-    return n == 0;
+    return n == 0 || errno == ENOENT;
 }
 
 // Check validity of password (user name is ignored).

--- a/termux-auth.c
+++ b/termux-auth.c
@@ -89,6 +89,14 @@ bool termux_change_passwd(const char *new_password) {
     return is_password_changed;
 }
 
+// Remove file that stores password hash
+// Return true on success, false otherwise.
+bool termux_remove_passwd(void) {
+    int n = remove(AUTH_HASH_FILE_PATH);
+
+    return n == 0;
+}
+
 // Check validity of password (user name is ignored).
 // Return true if password is ok, otherwise return false.
 bool termux_auth(const char *user, const char *password) {

--- a/termux-auth.h
+++ b/termux-auth.h
@@ -27,6 +27,10 @@ unsigned char *termux_passwd_hash(const char *password);
 // Return true on success, false otherwise.
 bool termux_change_passwd(const char *new_password);
 
+// Remove file that stores password hash
+// Return true on success, false otherwise.
+bool termux_remove_passwd(void);
+
 // Check validity of password (user name is ignored).
 // Return true if password is ok, otherwise return false.
 bool termux_auth(const char *user, const char *password);


### PR DESCRIPTION
Note: I haven’t yet been able to build this, but it seems like a simple change that should work.

This is two commits:
1. Fix a bug where `passwd` exits with zero exit code indicating success even on error. The variable `ret` was set up which would enable returning the correct exit code on error, but this wasn’t used. The commit returns `ret` as was probably originally intended.
2. Enable `passwd` to receive a `-l` argument that causes it to remove the `.termux_authinfo` file, in analogy to shadow’s passwd’s -l option. This is accomplished by splitting `main` into two functions, `main_set_password` and `main_remove_password`, and adding the function `termux_remove_passwd`, analogous to `termux_set_passwd`, which `main_remove_password` calls. `main` itself is replaced by a simple `switch` to check the arguments.

This is technically a breaking change, though it breaks behaviors that I would expect weren’t and shouldn’t’ve been relied upon. Specifically:
1. The exit code on failure changes.
2. Arguments to `passwd` other than no arguments and a single `-l` are rejected, previously they were silently ignored.
3. Behavior of `passwd` when passed `-l` changes.